### PR TITLE
Fromsummary complex fix

### DIFF
--- a/src/walacor_sdk/data_requests/data_requests_service.py
+++ b/src/walacor_sdk/data_requests/data_requests_service.py
@@ -230,7 +230,7 @@ class DataRequestsService(BaseService):
     # ------------------------------------------------------------------ READ – complex/aggregate
 
     def post_complex_query(
-        self, ETId: int, pipeline: list[dict[str, Any]]
+        self, ETId: int, pipeline: list[dict[str, Any]], fromSummary: bool = False,
     ) -> ComplexQueryRecords | None:
         """Run an arbitrary Mongo‑style aggregation *pipeline* (``getcomplex``).
 
@@ -242,7 +242,8 @@ class DataRequestsService(BaseService):
             :class:`ComplexQueryRecords` or ``None`` on failure.
         """
         header = {"ETId": str(ETId)}
-        response = self._post("query/getcomplex", headers=header, json=pipeline)
+        query = f"query/getcomplex?fromSummary={'true' if fromSummary else 'false'}"
+        response = self._post(query, headers=header, json=pipeline)
 
         if not response or not response.get("success"):
             logger.error("Failed to fetch complex query results")
@@ -264,6 +265,7 @@ class DataRequestsService(BaseService):
         schemaVersion: int = 1,
         pageNumber: int = 1,
         pageSize: int = 0,
+        fromSummary: bool = False
     ) -> list[str] | None:
         """Endpoint helper for the simplified *query API*.
 
@@ -278,7 +280,7 @@ class DataRequestsService(BaseService):
             Raw JSON *strings* returned by the platform or ``None``.
         """
         headers = {"ETId": str(ETId), "SV": str(schemaVersion)}
-        query = f"query/get?pageNo={pageNumber}&pageSize={pageSize}"
+        query = f"query/get?pageNo={pageNumber}&pageSize={pageSize}&fromSummary={'true' if fromSummary else 'false'}"
         response = self._post(query, headers=headers, json=payload)
 
         if not response or not response.get("success"):
@@ -298,6 +300,7 @@ class DataRequestsService(BaseService):
         ETId: int = 10,
         schemaVersion: int = 1,
         dataVersion: int = 1,
+        fromSummary: bool = False
     ) -> QueryApiAggregate | None:
         """Wrapper for *query/getComplex* when using the **aggregate** flavour.
 
@@ -315,7 +318,9 @@ class DataRequestsService(BaseService):
             "SV": str(schemaVersion),
             "DV": str(dataVersion),
         }
-        response = self._post("query/getComplex", headers=headers, json=payload)
+
+        query = f"query/getComplex?fromSummary={'true' if fromSummary else 'false'}"
+        response = self._post(query, headers=headers, json=payload)
 
         if not response or not response.get("success"):
             logger.error("Failed to fetch aggregate results")
@@ -334,6 +339,7 @@ class DataRequestsService(BaseService):
         self,
         pipeline: list[dict[str, Any]],
         ETId: int,
+        fromSummary: bool = False
     ) -> ComplexQMLQueryRecords | None:
         """Pass‑through helper for advanced *MQL* pipelines.
 
@@ -345,7 +351,8 @@ class DataRequestsService(BaseService):
             :class:`ComplexQMLQueryRecords` or ``None``.
         """
         header = {"ETId": str(ETId)}
-        response = self._post("query/getcomplex", headers=header, json=pipeline)
+        query = f"query/getcomplex?fromSummary={'true' if fromSummary else 'false'}"
+        response = self._post(query, headers=header, json=pipeline)
 
         if not response or not response.get("success"):
             logger.error("Failed to fetch MQL query results")

--- a/tests/test_data_requests.py
+++ b/tests/test_data_requests.py
@@ -479,7 +479,7 @@ def test_post_complex_query_success(mock_logging, service):
         assert result.Total == 1
         assert isinstance(result.Records, list)
         service._post.assert_called_once_with(
-            "query/getcomplex",
+            "query/getcomplex?fromSummary=false",
             headers={"ETId": "101"},
             json=[{"match": "criteria"}],
         )
@@ -530,7 +530,7 @@ def test_post_query_api_success(mock_logging, service):
 
         assert result == ["row1", "row2"]
         service._post.assert_called_once_with(
-            "query/get?pageNo=1&pageSize=0",
+            "query/get?pageNo=1&pageSize=0&fromSummary=false",
             headers={"ETId": "22", "SV": "1"},
             json={"some": "query"},
         )
@@ -586,7 +586,7 @@ def test_post_query_api_aggregate_success(mock_logging, service):
         assert result.Total == 3
         assert isinstance(result.Records, list)
         service._post.assert_called_once_with(
-            "query/getComplex",
+            "query/getComplex?fromSummary=false",
             headers={"ETId": "10", "SV": "1", "DV": "1"},
             json={"agg": "test"},
         )
@@ -645,7 +645,7 @@ def test_post_complex_MQL_queries_success(mock_logging, service):
         assert result.Total == 99
         assert isinstance(result.Records, list)
         service._post.assert_called_once_with(
-            "query/getcomplex", headers={"ETId": "77"}, json=[{"stage": "match"}]
+            "query/getcomplex?fromSummary=false", headers={"ETId": "77"}, json=[{"stage": "match"}]
         )
         mock_logging.error.assert_not_called()
 


### PR DESCRIPTION
## Summary

The complex query endpoints (`post_complex_query`, `post_query_api`, `post_query_api_aggregate`, `post_complex_MQL_queries`) were hardcoded to always query the summary table, making the majority of records unreachable through the SDK with no workaround.

This adds a `fromSummary: bool = False` parameter to each of those methods and threads it through to the query string, defaulting to the full table so existing call sites are unaffected.

## Changes

- `data_requests_service.py` — added `fromSummary` parameter and updated query string construction for all four complex endpoints
- `tests/test_data_requests.py` — updated the four affected success test assertions to expect the new `?fromSummary=false` query param