### PR TITLE
A fromSummary Support to query Endpoints

### DIFF
--- a/src/walacor_sdk/data_requests/data_requests_service.py
+++ b/src/walacor_sdk/data_requests/data_requests_service.py
@@ -271,6 +271,7 @@ class DataRequestsService(BaseService):
 
         Args:
             ETId: Envelope‑type ID.
+            payload: Query filter object (see Walacor docs).
             schemaVersion: `SV` header value – defaults to latest (``1``).
             pageNumber: 1‑based index of the page to retrieve.
             pageSize: Number of rows per page (``0`` = no limit).

--- a/src/walacor_sdk/data_requests/data_requests_service.py
+++ b/src/walacor_sdk/data_requests/data_requests_service.py
@@ -230,7 +230,7 @@ class DataRequestsService(BaseService):
     # ------------------------------------------------------------------ READ – complex/aggregate
 
     def post_complex_query(
-        self, ETId: int, pipeline: list[dict[str, Any]]
+        self, ETId: int, pipeline: list[dict[str, Any]], fromSummary: bool = True
     ) -> ComplexQueryRecords | None:
         """Run an arbitrary Mongo‑style aggregation *pipeline* (``getcomplex``).
 
@@ -242,7 +242,8 @@ class DataRequestsService(BaseService):
             :class:`ComplexQueryRecords` or ``None`` on failure.
         """
         header = {"ETId": str(ETId)}
-        response = self._post("query/getcomplex", headers=header, json=pipeline)
+        query = f"query/getcomplex?fromSummary={'true' if fromSummary else 'false'}"
+        response = self._post(query, headers=header, json=pipeline)
 
         if not response or not response.get("success"):
             logger.error("Failed to fetch complex query results")
@@ -260,26 +261,26 @@ class DataRequestsService(BaseService):
     def post_query_api(
         self,
         ETId: int,
-        payload: dict[str, Any],
         schemaVersion: int = 1,
-        pageNumber: int = 1,
+        pageNumber: int = 0,
         pageSize: int = 0,
-    ) -> list[str] | None:
+        fromSummary: bool = True,
+    ) -> list[dict[str, Any]] | None:
         """Endpoint helper for the simplified *query API*.
 
         Args:
             ETId: Envelope‑type ID.
-            payload: Query filter object (see Walacor docs).
             schemaVersion: `SV` header value – defaults to latest (``1``).
             pageNumber: 1‑based index of the page to retrieve.
             pageSize: Number of rows per page (``0`` = no limit).
+            fromSummary: Query summary table instead of full detail.
 
         Returns:
             Raw JSON *strings* returned by the platform or ``None``.
         """
         headers = {"ETId": str(ETId), "SV": str(schemaVersion)}
-        query = f"query/get?pageNo={pageNumber}&pageSize={pageSize}"
-        response = self._post(query, headers=headers, json=payload)
+        query = f"query/get?pageNo={pageNumber}&pageSize={pageSize}&fromSummary={'true' if fromSummary else 'false'}"
+        response = self._post(query, headers=headers)
 
         if not response or not response.get("success"):
             logger.error("Failed to fetch query results")
@@ -298,6 +299,7 @@ class DataRequestsService(BaseService):
         ETId: int = 10,
         schemaVersion: int = 1,
         dataVersion: int = 1,
+        fromSummary: bool = True,
     ) -> QueryApiAggregate | None:
         """Wrapper for *query/getComplex* when using the **aggregate** flavour.
 
@@ -306,6 +308,7 @@ class DataRequestsService(BaseService):
             ETId: Primary collection ETId – default ``10``.
             schemaVersion: `SV` header value.
             dataVersion: `DV` header value.
+            fromSummary: Query summary table instead of full detail.
 
         Returns:
             :class:`QueryApiAggregate` with ``Records`` and ``Total`` or ``None``.
@@ -315,7 +318,8 @@ class DataRequestsService(BaseService):
             "SV": str(schemaVersion),
             "DV": str(dataVersion),
         }
-        response = self._post("query/getComplex", headers=headers, json=payload)
+        query = f"query/getcomplex?fromSummary={'true' if fromSummary else 'false'}"
+        response = self._post(query, headers=headers, json=payload)
 
         if not response or not response.get("success"):
             logger.error("Failed to fetch aggregate results")
@@ -334,18 +338,22 @@ class DataRequestsService(BaseService):
         self,
         pipeline: list[dict[str, Any]],
         ETId: int,
+        fromSummary: bool = True,
     ) -> ComplexQMLQueryRecords | None:
         """Pass‑through helper for advanced *MQL* pipelines.
 
         Args:
             pipeline: Mongo Query Language aggregate pipeline.
             ETId: Primary collection envelope‑type ID.
+            fromSummary: Query summary table instead of full detail.
 
         Returns:
             :class:`ComplexQMLQueryRecords` or ``None``.
         """
         header = {"ETId": str(ETId)}
-        response = self._post("query/getcomplex", headers=header, json=pipeline)
+        query = f"query/getcomplex?fromSummary={'true' if fromSummary else 'false'}"
+
+        response = self._post(query, headers=header, json=pipeline)
 
         if not response or not response.get("success"):
             logger.error("Failed to fetch MQL query results")

--- a/src/walacor_sdk/data_requests/data_requests_service.py
+++ b/src/walacor_sdk/data_requests/data_requests_service.py
@@ -261,6 +261,7 @@ class DataRequestsService(BaseService):
     def post_query_api(
         self,
         ETId: int,
+        payload: list[dict[str, Any]] | None = None,
         schemaVersion: int = 1,
         pageNumber: int = 0,
         pageSize: int = 0,
@@ -280,7 +281,7 @@ class DataRequestsService(BaseService):
         """
         headers = {"ETId": str(ETId), "SV": str(schemaVersion)}
         query = f"query/get?pageNo={pageNumber}&pageSize={pageSize}&fromSummary={'true' if fromSummary else 'false'}"
-        response = self._post(query, headers=headers)
+        response = self._post(query, headers=headers, json=payload)
 
         if not response or not response.get("success"):
             logger.error("Failed to fetch query results")

--- a/src/walacor_sdk/data_requests/models/data_request_response.py
+++ b/src/walacor_sdk/data_requests/models/data_request_response.py
@@ -24,7 +24,7 @@ class GetComplexQueryResponse(BaseResponse[list[dict[str, Any]]]):
     Total: int = Field(..., alias="total")
 
 
-class QueryApiResponse(BaseResponse[list[str]]):
+class QueryApiResponse(BaseResponse[list[dict[str, Any]]]):
     pass
 
 

--- a/tests/test_data_requests.py
+++ b/tests/test_data_requests.py
@@ -532,6 +532,7 @@ def test_post_query_api_success(mock_logging, service):
         service._post.assert_called_once_with(
             "query/get?pageNo=0&pageSize=0&fromSummary=true",
             headers={"ETId": "22", "SV": "1"},
+            json=None,
         )
         mock_logging.error.assert_not_called()
 

--- a/tests/test_data_requests.py
+++ b/tests/test_data_requests.py
@@ -479,7 +479,7 @@ def test_post_complex_query_success(mock_logging, service):
         assert result.Total == 1
         assert isinstance(result.Records, list)
         service._post.assert_called_once_with(
-            "query/getcomplex",
+            "query/getcomplex?fromSummary=true",
             headers={"ETId": "101"},
             json=[{"match": "criteria"}],
         )
@@ -526,13 +526,12 @@ def test_post_query_api_success(mock_logging, service):
         "walacor_sdk.data_requests.data_requests_service.QueryApiResponse",
         return_value=MagicMock(data=["row1", "row2"]),
     ):
-        result = service.post_query_api(ETId=22, payload={"some": "query"})
+        result = service.post_query_api(ETId=22)
 
         assert result == ["row1", "row2"]
         service._post.assert_called_once_with(
-            "query/get?pageNo=1&pageSize=0",
+            "query/get?pageNo=0&pageSize=0&fromSummary=true",
             headers={"ETId": "22", "SV": "1"},
-            json={"some": "query"},
         )
         mock_logging.error.assert_not_called()
 
@@ -542,7 +541,7 @@ def test_post_query_api_failure_flag(mock_logging, service):
     """Test post_query_api returns None and logs error when response is unsuccessful."""
     service._post = MagicMock(return_value={"success": False})
 
-    result = service.post_query_api(ETId=7, payload={"bad": "query"})
+    result = service.post_query_api(ETId=7)
 
     assert result is None
     mock_logging.error.assert_called_once_with("Failed to fetch query results")
@@ -557,7 +556,7 @@ def test_post_query_api_validation_error(mock_logging, service):
         "walacor_sdk.data_requests.data_requests_service.QueryApiResponse",
         side_effect=ValidationError.from_exception_data("QueryApiResponse", []),
     ):
-        result = service.post_query_api(ETId=5, payload={})
+        result = service.post_query_api(ETId=5)
 
         assert result is None
         mock_logging.error.assert_called()
@@ -586,7 +585,7 @@ def test_post_query_api_aggregate_success(mock_logging, service):
         assert result.Total == 3
         assert isinstance(result.Records, list)
         service._post.assert_called_once_with(
-            "query/getComplex",
+            "query/getcomplex?fromSummary=true",
             headers={"ETId": "10", "SV": "1", "DV": "1"},
             json={"agg": "test"},
         )
@@ -645,7 +644,9 @@ def test_post_complex_MQL_queries_success(mock_logging, service):
         assert result.Total == 99
         assert isinstance(result.Records, list)
         service._post.assert_called_once_with(
-            "query/getcomplex", headers={"ETId": "77"}, json=[{"stage": "match"}]
+            "query/getcomplex?fromSummary=true",
+            headers={"ETId": "77"},
+            json=[{"stage": "match"}],
         )
         mock_logging.error.assert_not_called()
 


### PR DESCRIPTION
## Changes

Add fromSummary: bool = False parameter to:

post_complex_query(...)

post_query_api_aggregate(...)

post_complex_MQL_queries(...)

Append fromSummary=true|false to the request URL for these endpoints.

Update response model typing for Query API responses (if applicable).

Update tests in tests/test_data_requests.py to assert the updated URL.